### PR TITLE
Add minor ticks support

### DIFF
--- a/core/shared/src/main/scala/chartreuse/PlotModule.scala
+++ b/core/shared/src/main/scala/chartreuse/PlotModule.scala
@@ -85,12 +85,12 @@ trait PlotModule(numberFormat: NumberFormat) {
       val xTicksMapped = Ticks(
         scale(Point(xTicks.min, 0)).x,
         scale(Point(xTicks.max, 0)).x,
-        scale(Point(xTicks.size, 0)).x
+        xTicks.size
       )
       val yTicksMapped = Ticks(
         scale(Point(0, yTicks.min)).y,
         scale(Point(0, yTicks.max)).y,
-        scale(Point(0, yTicks.size)).y
+        yTicks.size
       )
 
       // Convert the Ticks to a sequence of points
@@ -138,7 +138,6 @@ trait PlotModule(numberFormat: NumberFormat) {
         toIntervalX,
         xMajorTickToMinorTick
       )
-
       val yMinorTicksSequence = convertToMinorTicks(
         yTicksSequence,
         toIntervalY,

--- a/core/shared/src/main/scala/chartreuse/PlotModule.scala
+++ b/core/shared/src/main/scala/chartreuse/PlotModule.scala
@@ -41,6 +41,7 @@ trait PlotModule(numberFormat: NumberFormat) {
     ]
 
     private val margin = 10
+    private val minorTickCount = 3
 
     def addLayer[Alg2 <: Algebra](layer: Layer[?, Alg2]): Plot[Alg & Alg2] = {
       copy(layers = layer :: layers)
@@ -122,15 +123,17 @@ trait PlotModule(numberFormat: NumberFormat) {
       }
 
       val toIntervalX: TicksSequence => Double = ticksSequence => {
-        val (screenCoordinate, _) = ticksSequence.head
-        val (screenCoordinate2, _) = ticksSequence.tail.head
-        (screenCoordinate2.x - screenCoordinate.x) / 4
+        val here +: neighbour +: _ = ticksSequence
+        val (screenCoordinateHere, _) = here
+        val (screenCoordinateNeighbour, _) = neighbour
+        (screenCoordinateNeighbour.x - screenCoordinateHere.x) / (minorTickCount + 1)
       }
 
       val toIntervalY: TicksSequence => Double = ticksSequence => {
-        val (screenCoordinate, _) = ticksSequence.head
-        val (screenCoordinate2, _) = ticksSequence.tail.head
-        (screenCoordinate2.y - screenCoordinate.y) / 4
+        val here +: neighbour +: _ = ticksSequence
+        val (screenCoordinateHere, _) = here
+        val (screenCoordinateNeighbour, _) = neighbour
+        (screenCoordinateNeighbour.y - screenCoordinateHere.y) / (minorTickCount + 1)
       }
 
       val xMinorTicksSequence = convertToMinorTicks(
@@ -255,7 +258,7 @@ trait PlotModule(numberFormat: NumberFormat) {
       val minorTickInterval = toInterval(ticksSequence)
 
       ticksSequence.tail.flatMap { (screenCoordinate, _) =>
-        val minorTicks = for (i <- 1 to 3) yield {
+        val minorTicks = for (i <- 1 to minorTickCount) yield {
           majorTickToMinor(screenCoordinate, minorTickInterval, i)
         }
 


### PR DESCRIPTION
Add minor ticks layout for `Plot`

**Example:**

![image_2023-07-18_17-49-15](https://github.com/creativescala/chartreuse/assets/72448226/4663f1fa-14e7-4459-a9c2-8e95d8fd64fe)
