### PR TITLE
Fix tick labels layout

### DIFF
--- a/core/shared/src/main/scala/chartreuse/PlotModule.scala
+++ b/core/shared/src/main/scala/chartreuse/PlotModule.scala
@@ -39,7 +39,9 @@ trait PlotModule(numberFormat: NumberFormat) {
       Unit
     ]
 
-    private val margin = 10
+    private val axisMargin = 10
+    private val textMargin = axisMargin + tickSize + 5
+    private val majorTickCount = 12
 
     def addLayer[Alg2 <: Algebra](layer: Layer[?, Alg2]): Plot[Alg & Alg2] = {
       copy(layers = layer :: layers)
@@ -73,8 +75,10 @@ trait PlotModule(numberFormat: NumberFormat) {
 
       val scale = Scale.linear.build(dataBoundingBox, width, height)
 
-      val xTicks = TickMarkCalculator.calculateTickScale(minX, maxX, 12)
-      val yTicks = TickMarkCalculator.calculateTickScale(minY, maxY, 12)
+      val xTicks =
+        TickMarkCalculator.calculateTickScale(minX, maxX, majorTickCount)
+      val yTicks =
+        TickMarkCalculator.calculateTickScale(minY, maxY, majorTickCount)
 
       // Map the Ticks to the screen coordinates
       val xTicksMapped = Ticks(
@@ -102,24 +106,32 @@ trait PlotModule(numberFormat: NumberFormat) {
       val createXTick: ScreenCoordinate => OpenPath =
         screenCoordinate =>
           OpenPath.empty
-            .moveTo(screenCoordinate.x, yTicksMapped.min - margin)
-            .lineTo(screenCoordinate.x, yTicksMapped.min - margin - tickSize)
+            .moveTo(screenCoordinate.x, yTicksMapped.min - axisMargin)
+            .lineTo(
+              screenCoordinate.x,
+              yTicksMapped.min - axisMargin - tickSize
+            )
 
       val createXTickLabel: (ScreenCoordinate, DataCoordinate) => PlotPicture =
         (screenCoordinate, dataCoordinate) =>
           text(numberFormat.format(dataCoordinate.x))
-            .at(screenCoordinate.x, yTicksMapped.min - 30)
+            .originAt(Landmark.percent(0, 100))
+            .at(screenCoordinate.x, yTicksMapped.min - textMargin)
 
       val createYTick: ScreenCoordinate => OpenPath =
         screenCoordinate =>
           OpenPath.empty
-            .moveTo(xTicksMapped.min - margin, screenCoordinate.y)
-            .lineTo(xTicksMapped.min - margin - tickSize, screenCoordinate.y)
+            .moveTo(xTicksMapped.min - axisMargin, screenCoordinate.y)
+            .lineTo(
+              xTicksMapped.min - axisMargin - tickSize,
+              screenCoordinate.y
+            )
 
       val createYTickLabel: (ScreenCoordinate, DataCoordinate) => PlotPicture =
         (screenCoordinate, dataCoordinate) =>
           text(numberFormat.format(dataCoordinate.y))
-            .at(xTicksMapped.min - 45, screenCoordinate.y)
+            .originAt(Landmark.percent(100, 0))
+            .at(xTicksMapped.min - textMargin, screenCoordinate.y)
 
       val plotTitle = text(this.plotTitle)
         .scale(2, 2)
@@ -197,10 +209,10 @@ trait PlotModule(numberFormat: NumberFormat) {
         yTicksMapped: Ticks
     ): PlotPicture = {
       ClosedPath.empty
-        .moveTo(xTicksMapped.min - margin, yTicksMapped.min - margin)
-        .lineTo(xTicksMapped.max + margin, yTicksMapped.min - margin)
-        .lineTo(xTicksMapped.max + margin, yTicksMapped.max + margin)
-        .lineTo(xTicksMapped.min - margin, yTicksMapped.max + margin)
+        .moveTo(xTicksMapped.min - axisMargin, yTicksMapped.min - axisMargin)
+        .lineTo(xTicksMapped.max + axisMargin, yTicksMapped.min - axisMargin)
+        .lineTo(xTicksMapped.max + axisMargin, yTicksMapped.max + axisMargin)
+        .lineTo(xTicksMapped.min - axisMargin, yTicksMapped.max + axisMargin)
         .path
     }
 
@@ -217,8 +229,8 @@ trait PlotModule(numberFormat: NumberFormat) {
           plot
             .on(
               OpenPath.empty
-                .moveTo(screenCoordinate.x, yTicksMapped.min - margin)
-                .lineTo(screenCoordinate.x, yTicksMapped.max + margin)
+                .moveTo(screenCoordinate.x, yTicksMapped.min - axisMargin)
+                .lineTo(screenCoordinate.x, yTicksMapped.max + axisMargin)
                 .path
                 .strokeColor(Color.gray)
                 .strokeWidth(0.5)
@@ -232,8 +244,8 @@ trait PlotModule(numberFormat: NumberFormat) {
               plot
                 .on(
                   OpenPath.empty
-                    .moveTo(xTicksMapped.min - margin, screenCoordinate.y)
-                    .lineTo(xTicksMapped.max + margin, screenCoordinate.y)
+                    .moveTo(xTicksMapped.min - axisMargin, screenCoordinate.y)
+                    .lineTo(xTicksMapped.max + axisMargin, screenCoordinate.y)
                     .path
                     .strokeColor(Color.gray)
                     .strokeWidth(0.5)


### PR DESCRIPTION
Updated tick labels layout. The layout is now correct with big numbers.

**Example:**

![image](https://github.com/creativescala/chartreuse/assets/72448226/9b95d0dd-440b-43f7-b335-834c771ab5e6)

This works well for the Y-axis. For the X-axis we need to rotate labels to avoid overlapping. We need to think about how to determine if it is necessary to rotate the labels. I think we can check if the first two labels or the last two labels overlap, as they are supposed to be the longest strings.

On the other hand, even some labels in the middle can overlap in the following cases:
- The plot width is too small, the outer labels might be single-digit integers, and some labels in the middle might be floating-point numbers, which are generally longer
- With categorical data, the length of the label doesn't depend on its position

Considering this, it might be necessary to traverse the whole sequence of labels to determine if they overlap.