### PR TITLE
Add manual ticks layout

### DIFF
--- a/core/shared/src/main/scala/chartreuse/Axes.scala
+++ b/core/shared/src/main/scala/chartreuse/Axes.scala
@@ -20,6 +20,8 @@ import doodle.algebra.*
 import doodle.core.*
 import doodle.syntax.all.*
 
+import Plot.PlotAlg
+
 final case class Axes[-Alg <: Algebra](
     xTickLayout: MajorTickLayout,
     yTickLayout: MajorTickLayout,
@@ -29,6 +31,8 @@ final case class Axes[-Alg <: Algebra](
     width: Int,
     height: Int
 ) {
+  type TicksSequence = Seq[(ScreenCoordinate, DataCoordinate)]
+
   private val tickSize = 7
   private val axisMargin = 10
   private val textMargin = axisMargin + tickSize + 5

--- a/core/shared/src/main/scala/chartreuse/Axes.scala
+++ b/core/shared/src/main/scala/chartreuse/Axes.scala
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2023 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chartreuse
+
+import doodle.algebra.*
+import doodle.core.*
+import doodle.syntax.all.*
+
+final case class Axes[-Alg <: Algebra](
+    xTickLayout: MajorTickLayout,
+    yTickLayout: MajorTickLayout,
+    minorTickLayout: MinorTickLayout,
+    grid: Boolean,
+    layers: Seq[Layer[?, Alg]],
+    width: Int,
+    height: Int
+) {
+  private val tickSize = 7
+  private val axisMargin = 10
+  private val textMargin = axisMargin + tickSize + 5
+
+  def build(using
+      numberFormat: NumberFormat
+  ): Picture[Alg & PlotAlg, Unit] = {
+    val dataBoundingBox = layers.foldLeft(BoundingBox.empty) { (bb, layer) =>
+      bb.on(layer.boundingBox)
+    }
+
+    val dataMinX = dataBoundingBox.left
+    val dataMaxX = dataBoundingBox.right
+    val dataMinY = dataBoundingBox.bottom
+    val dataMaxY = dataBoundingBox.top
+
+    val scale = Scale.linear.build(dataBoundingBox, width, height)
+
+    // Convert the Ticks to a sequence of points
+    val asX: Double => Point = x => Point(x, 0)
+    val asY: Double => Point = y => Point(0, y)
+    val xFilter: Double => Boolean = tick =>
+      tick >= dataMinX - axisMargin && tick <= dataMaxX + axisMargin
+    val yFilter: Double => Boolean = tick =>
+      tick >= dataMinY - axisMargin && tick <= dataMaxY + axisMargin
+
+    val xTicksSequence: TicksSequence =
+      majorTickLayoutToSequence(xTickLayout, scale, asX, xFilter, dataMinX, dataMaxX)
+    val yTicksSequence: TicksSequence =
+      majorTickLayoutToSequence(yTickLayout, scale, asY, yFilter, dataMinY, dataMaxY)
+
+    val xMajorTickToMinorTick: (ScreenCoordinate, Double, Int) => (
+        ScreenCoordinate,
+        DataCoordinate
+    ) = (screenCoordinate, interval, i) => {
+      val x = screenCoordinate.x - interval * i
+      (
+        ScreenCoordinate(x, 0),
+        DataCoordinate(x, 0)
+      )
+    }
+
+    val yMajorTickToMinorTick: (ScreenCoordinate, Double, Int) => (
+        ScreenCoordinate,
+        DataCoordinate
+    ) = (screenCoordinate, interval, i) => {
+      val y = screenCoordinate.y - interval * i
+      (
+        ScreenCoordinate(0, y),
+        DataCoordinate(0, y)
+      )
+    }
+
+    val xMinorTicksSequence = minorTickLayoutToSequence(
+      minorTickLayout,
+      xTicksSequence,
+      xMajorTickToMinorTick,
+      coordinate => coordinate.x
+    )
+    val yMinorTicksSequence = minorTickLayoutToSequence(
+      minorTickLayout,
+      yTicksSequence,
+      yMajorTickToMinorTick,
+      coordinate => coordinate.y
+    )
+
+    val (xTicksMinCoordinate, _) = xTicksSequence.head
+    val (xTicksMaxCoordinate, _) = xTicksSequence.last
+    val (yTicksMinCoordinate, _) = yTicksSequence.head
+    val (yTicksMaxCoordinate, _) = yTicksSequence.last
+
+    val xTicksMin = xTicksMinCoordinate.x
+    val xTicksMax = xTicksMaxCoordinate.x
+    val yTicksMin = yTicksMinCoordinate.y
+    val yTicksMax = yTicksMaxCoordinate.y
+
+    val createXTick: (ScreenCoordinate, Int) => OpenPath =
+      (screenCoordinate, tickSize) =>
+        OpenPath.empty
+          .moveTo(screenCoordinate.x, yTicksMin - axisMargin)
+          .lineTo(
+            screenCoordinate.x,
+            yTicksMin - axisMargin - tickSize
+          )
+
+    val createXTickLabel
+        : (ScreenCoordinate, DataCoordinate) => Picture[Alg & PlotAlg, Unit] =
+      (screenCoordinate, dataCoordinate) =>
+        text(numberFormat.format(dataCoordinate.x))
+          .originAt(Landmark.percent(0, 100))
+          .at(screenCoordinate.x, yTicksMin - textMargin)
+
+    val createYTick: (ScreenCoordinate, Int) => OpenPath =
+      (screenCoordinate, tickSize) =>
+        OpenPath.empty
+          .moveTo(xTicksMin - axisMargin, screenCoordinate.y)
+          .lineTo(
+            xTicksMin - axisMargin - tickSize,
+            screenCoordinate.y
+          )
+
+    val createYTickLabel
+        : (ScreenCoordinate, DataCoordinate) => Picture[Alg & PlotAlg, Unit] =
+      (screenCoordinate, dataCoordinate) =>
+        text(numberFormat.format(dataCoordinate.y))
+          .originAt(Landmark.percent(100, 0))
+          .at(xTicksMin - textMargin, screenCoordinate.y)
+
+    withTicks(xTicksSequence, createXTick, createXTickLabel, tickSize)
+      .on(
+        withTicks(yTicksSequence, createYTick, createYTickLabel, tickSize)
+      )
+      .on(withAxes(xTicksMin, xTicksMax, yTicksMin, yTicksMax))
+      .on(
+        if grid then
+          withGrid(
+            xTicksMin,
+            xTicksMax,
+            yTicksMin,
+            yTicksMax,
+            xTicksSequence,
+            yTicksSequence
+          )
+        else empty[Shape]
+      )
+      .on(
+        withTicks(
+          xMinorTicksSequence,
+          createXTick,
+          (_, _) => empty[Shape],
+          tickSize / 2
+        )
+          .on(
+            withTicks(
+              yMinorTicksSequence,
+              createYTick,
+              (_, _) => empty[Shape],
+              tickSize / 2
+            )
+          )
+      )
+  }
+
+  private def majorTickLayoutToSequence(
+      tickLayout: MajorTickLayout,
+      scale: Bijection[Point, Point],
+      toPoint: Double => Point,
+      filter: Double => Boolean,
+      min: Double,
+      max: Double
+  ): TicksSequence = {
+    tickLayout match {
+      case MajorTickLayout.Manual(ticks) =>
+        manualTicksToSequence(ticks, scale, toPoint, filter)
+      case MajorTickLayout.Algorithmic(tickCount) =>
+        automaticTicksToSequence(
+          TickMarkCalculator.calculateTickScale(min, max, tickCount),
+          scale,
+          toPoint
+        )
+      case MajorTickLayout.NoTicks =>
+        List.empty[(ScreenCoordinate, DataCoordinate)]
+    }
+  }
+
+  private def minorTickLayoutToSequence(
+      minorTickLayout: MinorTickLayout,
+      ticksSequence: TicksSequence,
+      majorTickToMinorTick: (ScreenCoordinate, Double, Int) => (
+          ScreenCoordinate,
+          DataCoordinate
+      ),
+      coordinateToDouble: ScreenCoordinate => Double
+  ): TicksSequence = {
+    minorTickLayout match {
+      case MinorTickLayout.Algorithmic(tickCount) =>
+        convertToMinorTicks(
+          ticksSequence,
+          majorTickToMinorTick,
+          tickCount,
+          coordinateToDouble
+        )
+      case MinorTickLayout.NoTicks =>
+        List.empty[(ScreenCoordinate, DataCoordinate)]
+    }
+  }
+
+  private def automaticTicksToSequence(
+      ticks: Ticks,
+      scale: Bijection[Point, Point],
+      toPoint: Double => Point
+  ): TicksSequence = {
+    (0 to ((ticks.max - ticks.min) / ticks.size).toInt)
+      .map(i =>
+        (
+          ScreenCoordinate(scale(toPoint(ticks.min + i * ticks.size))),
+          DataCoordinate(toPoint(ticks.min + i * ticks.size))
+        )
+      )
+      .toList
+  }
+
+  private def manualTicksToSequence(
+      ticks: Seq[Double],
+      scale: Bijection[Point, Point],
+      toPoint: Double => Point,
+      filter: Double => Boolean
+  ): TicksSequence = {
+    ticks
+      .filter { tick =>
+        filter(tick)
+      }
+      .map { tick =>
+        (ScreenCoordinate(scale(toPoint(tick))), DataCoordinate(toPoint(tick)))
+      }
+  }
+
+  private def convertToMinorTicks(
+      ticksSequence: TicksSequence,
+      majorTickToMinor: (ScreenCoordinate, Double, Int) => (
+          ScreenCoordinate,
+          DataCoordinate
+      ),
+      tickCount: Int,
+      coordinateToDouble: ScreenCoordinate => Double
+  ): TicksSequence = {
+    var prev = ticksSequence.head
+    ticksSequence.tail.flatMap { tick =>
+      val (screenCoordinate, _) = tick
+      val (prevScreenCoordinate, _) = prev
+      val interval = (coordinateToDouble(screenCoordinate) - coordinateToDouble(
+        prevScreenCoordinate
+      )) / (tickCount + 1)
+      val minorTicks = for (i <- 1 to tickCount) yield {
+        majorTickToMinor(screenCoordinate, interval, i)
+      }
+      prev = tick
+
+      minorTicks
+    }
+  }
+
+  private def withTicks(
+      ticksSequence: TicksSequence,
+      createTick: (ScreenCoordinate, Int) => OpenPath,
+      createTickLabel: (
+          ScreenCoordinate,
+          DataCoordinate
+      ) => Picture[Alg & PlotAlg, Unit],
+      tickSize: Int
+  ): Picture[Alg & PlotAlg, Unit] = {
+    ticksSequence
+      .foldLeft(empty[Alg & PlotAlg])((plot, tick) =>
+        val (screenCoordinate, dataCoordinate) = tick
+
+        plot
+          .on(createTick(screenCoordinate, tickSize).path)
+          .on(createTickLabel(screenCoordinate, dataCoordinate))
+      )
+  }
+
+  private def withAxes(
+      xTicksMin: Double,
+      xTicksMax: Double,
+      yTicksMin: Double,
+      yTicksMax: Double
+  ): Picture[Alg & PlotAlg, Unit] = {
+    ClosedPath.empty
+      .moveTo(xTicksMin - axisMargin, yTicksMin - axisMargin)
+      .lineTo(xTicksMax + axisMargin, yTicksMin - axisMargin)
+      .lineTo(xTicksMax + axisMargin, yTicksMax + axisMargin)
+      .lineTo(xTicksMin - axisMargin, yTicksMax + axisMargin)
+      .path
+  }
+
+  private def withGrid(
+      xTicksMin: Double,
+      xTicksMax: Double,
+      yTicksMin: Double,
+      yTicksMax: Double,
+      xTicksSequence: TicksSequence,
+      yTicksSequence: TicksSequence
+  ): Picture[Alg & PlotAlg, Unit] = {
+    xTicksSequence
+      .foldLeft(empty[Layout & Path & Style & Shape])((plot, tick) =>
+        val (screenCoordinate, _) = tick
+
+        plot
+          .on(
+            OpenPath.empty
+              .moveTo(screenCoordinate.x, yTicksMin - axisMargin)
+              .lineTo(screenCoordinate.x, yTicksMax + axisMargin)
+              .path
+              .strokeColor(Color.gray)
+              .strokeWidth(0.5)
+          )
+      )
+      .on(
+        yTicksSequence
+          .foldLeft(empty[Layout & Path & Style & Shape])((plot, tick) =>
+            val (screenCoordinate, _) = tick
+
+            plot
+              .on(
+                OpenPath.empty
+                  .moveTo(xTicksMin - axisMargin, screenCoordinate.y)
+                  .lineTo(xTicksMax + axisMargin, screenCoordinate.y)
+                  .path
+                  .strokeColor(Color.gray)
+                  .strokeWidth(0.5)
+              )
+          )
+      )
+  }
+}

--- a/core/shared/src/main/scala/chartreuse/Axes.scala
+++ b/core/shared/src/main/scala/chartreuse/Axes.scala
@@ -120,22 +120,22 @@ final case class Axes[-Alg <: Algebra](
       else List.empty
 
     val xTicksMin = Math.min(
-      if xTickLayout != MajorTickLayout.NoTicks then xTicksSequence.head._1.x
+      if xTickLayout != MajorTickLayout.NoTicks then xTicksSequence.head(0).x
       else Double.MaxValue,
       scale(Point(dataMinX, 0)).x
     )
     val xTicksMax = Math.max(
-      if xTickLayout != MajorTickLayout.NoTicks then xTicksSequence.last._1.x
+      if xTickLayout != MajorTickLayout.NoTicks then xTicksSequence.last(0).x
       else Double.MinValue,
       scale(Point(dataMaxX, 0)).x
     )
     val yTicksMin = Math.min(
-      if yTickLayout != MajorTickLayout.NoTicks then yTicksSequence.head._1.y
+      if yTickLayout != MajorTickLayout.NoTicks then yTicksSequence.head(0).y
       else Double.MaxValue,
       scale(Point(0, dataMinY)).y
     )
     val yTicksMax = Math.max(
-      if yTickLayout != MajorTickLayout.NoTicks then yTicksSequence.last._1.y
+      if yTickLayout != MajorTickLayout.NoTicks then yTicksSequence.last(0).y
       else Double.MinValue,
       scale(Point(0, dataMaxY)).y
     )

--- a/core/shared/src/main/scala/chartreuse/Axes.scala
+++ b/core/shared/src/main/scala/chartreuse/Axes.scala
@@ -56,9 +56,23 @@ final case class Axes[-Alg <: Algebra](
       tick >= dataMinY && tick <= dataMaxY
 
     val xTicksSequence: TicksSequence =
-      majorTickLayoutToSequence(xTickLayout, scale, asX, xFilter, dataMinX, dataMaxX)
+      majorTickLayoutToSequence(
+        xTickLayout,
+        scale,
+        asX,
+        xFilter,
+        dataMinX,
+        dataMaxX
+      )
     val yTicksSequence: TicksSequence =
-      majorTickLayoutToSequence(yTickLayout, scale, asY, yFilter, dataMinY, dataMaxY)
+      majorTickLayoutToSequence(
+        yTickLayout,
+        scale,
+        asY,
+        yFilter,
+        dataMinY,
+        dataMaxY
+      )
 
     val xMajorTickToMinorTick: (ScreenCoordinate, Double, Int) => (
         ScreenCoordinate,
@@ -82,28 +96,45 @@ final case class Axes[-Alg <: Algebra](
       )
     }
 
-    val xMinorTicksSequence = minorTickLayoutToSequence(
-      minorTickLayout,
-      xTicksSequence,
-      xMajorTickToMinorTick,
-      coordinate => coordinate.x
-    )
-    val yMinorTicksSequence = minorTickLayoutToSequence(
-      minorTickLayout,
-      yTicksSequence,
-      yMajorTickToMinorTick,
-      coordinate => coordinate.y
-    )
+    val xMinorTicksSequence =
+      if xTickLayout != MajorTickLayout.NoTicks then
+        minorTickLayoutToSequence(
+          minorTickLayout,
+          xTicksSequence,
+          xMajorTickToMinorTick,
+          coordinate => coordinate.x
+        )
+      else List.empty
+    val yMinorTicksSequence =
+      if yTickLayout != MajorTickLayout.NoTicks then
+        minorTickLayoutToSequence(
+          minorTickLayout,
+          yTicksSequence,
+          yMajorTickToMinorTick,
+          coordinate => coordinate.y
+        )
+      else List.empty
 
-    val (xTicksMinCoordinate, _) = xTicksSequence.head
-    val (xTicksMaxCoordinate, _) = xTicksSequence.last
-    val (yTicksMinCoordinate, _) = yTicksSequence.head
-    val (yTicksMaxCoordinate, _) = yTicksSequence.last
-
-    val xTicksMin = Math.min(xTicksMinCoordinate.x, scale(Point(dataMinX, 0)).x)
-    val xTicksMax = Math.max(xTicksMaxCoordinate.x, scale(Point(dataMaxX, 0)).x)
-    val yTicksMin = Math.min(yTicksMinCoordinate.y, scale(Point(0, dataMinY)).y)
-    val yTicksMax = Math.max(yTicksMaxCoordinate.y, scale(Point(0, dataMaxY)).y)
+    val xTicksMin = Math.min(
+      if xTickLayout != MajorTickLayout.NoTicks then xTicksSequence.head._1.x
+      else Double.MaxValue,
+      scale(Point(dataMinX, 0)).x
+    )
+    val xTicksMax = Math.max(
+      if xTickLayout != MajorTickLayout.NoTicks then xTicksSequence.last._1.x
+      else Double.MinValue,
+      scale(Point(dataMaxX, 0)).x
+    )
+    val yTicksMin = Math.min(
+      if yTickLayout != MajorTickLayout.NoTicks then yTicksSequence.head._1.y
+      else Double.MaxValue,
+      scale(Point(0, dataMinY)).y
+    )
+    val yTicksMax = Math.max(
+      if yTickLayout != MajorTickLayout.NoTicks then yTicksSequence.last._1.y
+      else Double.MinValue,
+      scale(Point(0, dataMaxY)).y
+    )
 
     val createXTick: (ScreenCoordinate, Int) => OpenPath =
       (screenCoordinate, tickSize) =>
@@ -190,7 +221,7 @@ final case class Axes[-Alg <: Algebra](
           toPoint
         )
       case MajorTickLayout.NoTicks =>
-        List.empty[(ScreenCoordinate, DataCoordinate)]
+        List.empty
     }
   }
 
@@ -212,7 +243,7 @@ final case class Axes[-Alg <: Algebra](
           coordinateToDouble
         )
       case MinorTickLayout.NoTicks =>
-        List.empty[(ScreenCoordinate, DataCoordinate)]
+        List.empty
     }
   }
 

--- a/core/shared/src/main/scala/chartreuse/Axes.scala
+++ b/core/shared/src/main/scala/chartreuse/Axes.scala
@@ -51,9 +51,9 @@ final case class Axes[-Alg <: Algebra](
     val asX: Double => Point = x => Point(x, 0)
     val asY: Double => Point = y => Point(0, y)
     val xFilter: Double => Boolean = tick =>
-      tick >= dataMinX - axisMargin && tick <= dataMaxX + axisMargin
+      tick >= dataMinX && tick <= dataMaxX
     val yFilter: Double => Boolean = tick =>
-      tick >= dataMinY - axisMargin && tick <= dataMaxY + axisMargin
+      tick >= dataMinY && tick <= dataMaxY
 
     val xTicksSequence: TicksSequence =
       majorTickLayoutToSequence(xTickLayout, scale, asX, xFilter, dataMinX, dataMaxX)
@@ -100,10 +100,10 @@ final case class Axes[-Alg <: Algebra](
     val (yTicksMinCoordinate, _) = yTicksSequence.head
     val (yTicksMaxCoordinate, _) = yTicksSequence.last
 
-    val xTicksMin = xTicksMinCoordinate.x
-    val xTicksMax = xTicksMaxCoordinate.x
-    val yTicksMin = yTicksMinCoordinate.y
-    val yTicksMax = yTicksMaxCoordinate.y
+    val xTicksMin = Math.min(xTicksMinCoordinate.x, scale(Point(dataMinX, 0)).x)
+    val xTicksMax = Math.max(xTicksMaxCoordinate.x, scale(Point(dataMaxX, 0)).x)
+    val yTicksMin = Math.min(yTicksMinCoordinate.y, scale(Point(0, dataMinY)).y)
+    val yTicksMax = Math.max(yTicksMaxCoordinate.y, scale(Point(0, dataMaxY)).y)
 
     val createXTick: (ScreenCoordinate, Int) => OpenPath =
       (screenCoordinate, tickSize) =>

--- a/core/shared/src/main/scala/chartreuse/Coordinate.scala
+++ b/core/shared/src/main/scala/chartreuse/Coordinate.scala
@@ -16,14 +16,11 @@
 
 package chartreuse
 
-import doodle.algebra.*
 import doodle.core.Point
 
 opaque type Coordinate = Point
 opaque type ScreenCoordinate <: Coordinate = Point
 opaque type DataCoordinate <: Coordinate = Point
-type TicksSequence = Seq[(ScreenCoordinate, DataCoordinate)]
-type PlotAlg = Layout & Path & Style & Shape & Text & doodle.algebra.Transform
 
 extension (coordinate: Coordinate) {
   def x: Double = coordinate.x

--- a/core/shared/src/main/scala/chartreuse/Coordinate.scala
+++ b/core/shared/src/main/scala/chartreuse/Coordinate.scala
@@ -16,11 +16,14 @@
 
 package chartreuse
 
+import doodle.algebra.*
 import doodle.core.Point
 
 opaque type Coordinate = Point
 opaque type ScreenCoordinate <: Coordinate = Point
 opaque type DataCoordinate <: Coordinate = Point
+type TicksSequence = Seq[(ScreenCoordinate, DataCoordinate)]
+type PlotAlg = Layout & Path & Style & Shape & Text & doodle.algebra.Transform
 
 extension (coordinate: Coordinate) {
   def x: Double = coordinate.x

--- a/core/shared/src/main/scala/chartreuse/Plot.scala
+++ b/core/shared/src/main/scala/chartreuse/Plot.scala
@@ -20,6 +20,8 @@ import doodle.algebra.*
 import doodle.core.*
 import doodle.syntax.all.*
 
+import Plot.PlotAlg
+
 /** A `Plot` is a collection of layers along with a title, legend, axes, and
   * grid.
   */
@@ -96,6 +98,7 @@ final case class Plot[-Alg <: Algebra](
 }
 
 object Plot {
+  type PlotAlg = Layout & Path & Style & Shape & Text & doodle.algebra.Transform
 
   /** Utility constructor to create a `Plot` from a single layer. */
   def apply[Alg <: Algebra](layer: Layer[?, Alg]): Plot[Alg] =

--- a/core/shared/src/main/scala/chartreuse/Plot.scala
+++ b/core/shared/src/main/scala/chartreuse/Plot.scala
@@ -29,22 +29,10 @@ final case class Plot[-Alg <: Algebra](
     xTitle: String = "X data",
     yTitle: String = "Y data",
     grid: Boolean = false,
-    minorTicks: Boolean = false,
-    tickSize: Int = 7,
-    xUserTicks: Option[List[Double]] = None,
-    yUserTicks: Option[List[Double]] = None
+    xTicks: MajorTickLayout = MajorTickLayout.Algorithmic(12),
+    yTicks: MajorTickLayout = MajorTickLayout.Algorithmic(12),
+    minorTicks: MinorTickLayout = MinorTickLayout.NoTicks
 ) {
-  type TicksSequence = Seq[(ScreenCoordinate, DataCoordinate)]
-  type AAlg >: Alg
-  type PlotAlg = AAlg & Layout & Text & Path & Style & Shape &
-    doodle.algebra.Transform
-  type PlotPicture = Picture[PlotAlg, Unit]
-
-  private val axisMargin = 10
-  private val textMargin = axisMargin + tickSize + 5
-  private val majorTickCount = 12
-  private val minorTickCount = 3
-
   def addLayer[Alg2 <: Algebra](layer: Layer[?, Alg2]): Plot[Alg & Alg2] = {
     copy(layers = layer :: layers)
   }
@@ -65,138 +53,28 @@ final case class Plot[-Alg <: Algebra](
     copy(grid = newGrid)
   }
 
-  def withMinorTicks(newMinorTicks: Boolean): Plot[Alg] = {
+  def withMinorTicks(
+      newMinorTicks: MinorTickLayout = MinorTickLayout.Algorithmic(3)
+  ): Plot[Alg] = {
     copy(minorTicks = newMinorTicks)
   }
 
-  def withXUserTicks(newXUserTicks: List[Double]): Plot[Alg] = {
-    copy(xUserTicks = Some(newXUserTicks))
+  def withXTicks(newXTicks: MajorTickLayout): Plot[Alg] = {
+    copy(xTicks = newXTicks)
   }
 
-  def withYUserTicks(newYUserTicks: List[Double]): Plot[Alg] = {
-    copy(yUserTicks = Some(newYUserTicks))
+  def withYTicks(newYTicks: MajorTickLayout): Plot[Alg] = {
+    copy(yTicks = newYTicks)
   }
 
-  def draw(width: Int, height: Int)(using
-      numberFormat: NumberFormat
-  ): PlotPicture = {
-    val dataBoundingBox = layers.foldLeft(BoundingBox.empty) { (bb, layer) =>
-      bb.on(layer.boundingBox)
-    }
+  def draw(width: Int, height: Int): Picture[Alg & PlotAlg, Unit] = {
+    val axes = Axes(xTicks, yTicks, minorTicks, grid, layers, width, height)
+    val plotAttributes = axes.build
 
-    val minX = dataBoundingBox.left
-    val maxX = dataBoundingBox.right
-    val minY = dataBoundingBox.bottom
-    val maxY = dataBoundingBox.top
-
-    val scale = Scale.linear.build(dataBoundingBox, width, height)
-
-    val xTicks =
-      TickMarkCalculator.calculateTickScale(minX, maxX, majorTickCount)
-    val yTicks =
-      TickMarkCalculator.calculateTickScale(minY, maxY, majorTickCount)
-
-    // Map the Ticks to the screen coordinates
-    val xTicksMapped = Ticks(
-      scale(Point(xTicks.min, 0)).x,
-      scale(Point(xTicks.max, 0)).x,
-      scale(Point(xTicks.min + xTicks.size, 0)).x - scale(
-        Point(xTicks.min, 0)
-      ).x
-    )
-    val yTicksMapped = Ticks(
-      scale(Point(0, yTicks.min)).y,
-      scale(Point(0, yTicks.max)).y,
-      scale(Point(0, yTicks.min + yTicks.size)).y - scale(
-        Point(0, yTicks.min)
-      ).y
-    )
-
-    // Convert the Ticks to a sequence of points
-    val asX: Double => Point = x => Point(x, 0)
-    val asY: Double => Point = y => Point(0, y)
-    val xFilter: Double => Boolean = tick =>
-      tick >= xTicks.min && tick <= xTicks.max
-    val yFilter: Double => Boolean = tick =>
-      tick >= xTicks.min && tick <= yTicks.max
-
-    val xTicksSequence: TicksSequence =
-      ticksToSequence(xUserTicks, scale, asX, xFilter, xTicks)
-    val yTicksSequence: TicksSequence =
-      ticksToSequence(yUserTicks, scale, asY, yFilter, yTicks)
-
-    val xMajorTickToMinorTick: (ScreenCoordinate, Double, Int) => (
-        ScreenCoordinate,
-        DataCoordinate
-    ) = (screenCoordinate, interval, i) => {
-      val x = screenCoordinate.x - interval * i
-      (
-        ScreenCoordinate(x, 0),
-        DataCoordinate(x, 0)
-      )
-    }
-
-    val yMajorTickToMinorTick: (ScreenCoordinate, Double, Int) => (
-        ScreenCoordinate,
-        DataCoordinate
-    ) = (screenCoordinate, interval, i) => {
-      val y = screenCoordinate.y - interval * i
-      (
-        ScreenCoordinate(0, y),
-        DataCoordinate(0, y)
-      )
-    }
-
-    val xMinorTicksInterval = xTicksMapped.size / (minorTickCount + 1)
-    val yMinorTicksInterval = yTicksMapped.size / (minorTickCount + 1)
-
-    val xMinorTicksSequence = convertToMinorTicks(
-      xTicksSequence,
-      xMinorTicksInterval,
-      xMajorTickToMinorTick
-    )
-    val yMinorTicksSequence = convertToMinorTicks(
-      yTicksSequence,
-      yMinorTicksInterval,
-      yMajorTickToMinorTick
-    )
-
-    val allLayers: PlotPicture =
+    val allLayers: Picture[Alg & PlotAlg, Unit] =
       layers
         .map(_.draw(width, height))
-        .foldLeft(empty[PlotAlg])(
-          _ on _.asInstanceOf[PlotPicture]
-        )
-
-    val createXTick: (ScreenCoordinate, Int) => OpenPath =
-      (screenCoordinate, tickSize) =>
-        OpenPath.empty
-          .moveTo(screenCoordinate.x, yTicksMapped.min - axisMargin)
-          .lineTo(
-            screenCoordinate.x,
-            yTicksMapped.min - axisMargin - tickSize
-          )
-
-    val createXTickLabel: (ScreenCoordinate, DataCoordinate) => PlotPicture =
-      (screenCoordinate, dataCoordinate) =>
-        text(numberFormat.format(dataCoordinate.x))
-          .originAt(Landmark.percent(0, 100))
-          .at(screenCoordinate.x, yTicksMapped.min - textMargin)
-
-    val createYTick: (ScreenCoordinate, Int) => OpenPath =
-      (screenCoordinate, tickSize) =>
-        OpenPath.empty
-          .moveTo(xTicksMapped.min - axisMargin, screenCoordinate.y)
-          .lineTo(
-            xTicksMapped.min - axisMargin - tickSize,
-            screenCoordinate.y
-          )
-
-    val createYTickLabel: (ScreenCoordinate, DataCoordinate) => PlotPicture =
-      (screenCoordinate, dataCoordinate) =>
-        text(numberFormat.format(dataCoordinate.y))
-          .originAt(Landmark.percent(100, 0))
-          .at(xTicksMapped.min - textMargin, screenCoordinate.y)
+        .foldLeft(empty)(_ on _)
 
     val plotTitle = text(this.plotTitle)
       .scale(2, 2)
@@ -208,185 +86,15 @@ final case class Plot[-Alg <: Algebra](
       .beside(
         allLayers
           .on(
-            withTicks(xTicksSequence, createXTick, createXTickLabel, tickSize)
-          )
-          .on(
-            withTicks(yTicksSequence, createYTick, createYTickLabel, tickSize)
-          )
-          .on(withAxes(xTicksMapped, yTicksMapped))
-          .on(
-            if minorTicks then
-              withTicks(
-                xMinorTicksSequence,
-                createXTick,
-                (_, _) => empty[Shape],
-                tickSize / 2
-              )
-                .on(
-                  withTicks(
-                    yMinorTicksSequence,
-                    createYTick,
-                    (_, _) => empty[Shape],
-                    tickSize / 2
-                  )
-                )
-            else empty[Shape]
-          )
-          .on(
-            if grid then
-              withGrid(
-                xTicksMapped,
-                yTicksMapped,
-                xTicksSequence,
-                yTicksSequence
-              )
-            else empty[Shape]
+            plotAttributes
           )
           .margin(5)
           .below(plotTitle)
           .above(xTitle)
       )
-
-  }
-
-  private def ticksToSequence(
-      userTicks: Option[List[Double]],
-      scale: Bijection[Point, Point],
-      toPoint: Double => Point,
-      filter: Double => Boolean,
-      automaticTicks: Ticks
-  ): TicksSequence = {
-    userTicks match {
-      case Some(ticks) =>
-        userTicksToSequence(ticks, scale, toPoint, filter)
-      case None =>
-        automaticTicksToSequence(automaticTicks, scale, toPoint)
-    }
-  }
-
-  /** Converts `Ticks` to a list of tuples. The first element is the mapped
-    * coordinate of a tick, i.e. a screen coordinate - to place the tick on a
-    * graph. The second one is the original coordinate, i.e. a data coordinate
-    * \- to give the tick a label with its coordinate. Screen coordinates are
-    * the coordinates of the graph rendered on the screen. Data coordinates are
-    * the values in the data.
-    */
-  private def automaticTicksToSequence(
-      ticks: Ticks,
-      scale: Bijection[Point, Point],
-      toPoint: Double => Point
-  ): TicksSequence = {
-    (0 to ((ticks.max - ticks.min) / ticks.size).toInt)
-      .map(i =>
-        (
-          ScreenCoordinate(scale(toPoint(ticks.min + i * ticks.size))),
-          DataCoordinate(toPoint(ticks.min + i * ticks.size))
-        )
-      )
-      .toList
-  }
-
-  private def userTicksToSequence(
-      ticks: List[Double],
-      scale: Bijection[Point, Point],
-      toPoint: Double => Point,
-      filter: Double => Boolean
-  ): TicksSequence = {
-    ticks
-      .filter { tick =>
-        filter(tick)
-      }
-      .map { tick =>
-        (ScreenCoordinate(scale(toPoint(tick))), DataCoordinate(toPoint(tick)))
-      }
-  }
-
-  private def convertToMinorTicks(
-      ticksSequence: TicksSequence,
-      interval: Double,
-      majorTickToMinor: (ScreenCoordinate, Double, Int) => (
-          ScreenCoordinate,
-          DataCoordinate
-      )
-  ): TicksSequence = {
-    ticksSequence.tail.flatMap { (screenCoordinate, _) =>
-      val minorTicks = for (i <- 1 to minorTickCount) yield {
-        majorTickToMinor(screenCoordinate, interval, i)
-      }
-
-      minorTicks
-    }
-  }
-
-  private def withTicks(
-      ticksSequence: TicksSequence,
-      createTick: (ScreenCoordinate, Int) => OpenPath,
-      createTickLabel: (
-          ScreenCoordinate,
-          DataCoordinate
-      ) => PlotPicture,
-      tickSize: Int
-  ): PlotPicture = {
-    ticksSequence
-      .foldLeft(empty[PlotAlg])((plot, tick) =>
-        val (screenCoordinate, dataCoordinate) = tick
-
-        plot
-          .on(createTick(screenCoordinate, tickSize).path)
-          .on(createTickLabel(screenCoordinate, dataCoordinate))
-      )
-  }
-
-  private def withAxes(
-      xTicksMapped: Ticks,
-      yTicksMapped: Ticks
-  ): PlotPicture = {
-    ClosedPath.empty
-      .moveTo(xTicksMapped.min - axisMargin, yTicksMapped.min - axisMargin)
-      .lineTo(xTicksMapped.max + axisMargin, yTicksMapped.min - axisMargin)
-      .lineTo(xTicksMapped.max + axisMargin, yTicksMapped.max + axisMargin)
-      .lineTo(xTicksMapped.min - axisMargin, yTicksMapped.max + axisMargin)
-      .path
-  }
-
-  private def withGrid(
-      xTicksMapped: Ticks,
-      yTicksMapped: Ticks,
-      xTicksSequence: TicksSequence,
-      yTicksSequence: TicksSequence
-  ): PlotPicture = {
-    xTicksSequence
-      .foldLeft(empty[Layout & Path & Style & Shape])((plot, tick) =>
-        val (screenCoordinate, _) = tick
-
-        plot
-          .on(
-            OpenPath.empty
-              .moveTo(screenCoordinate.x, yTicksMapped.min - axisMargin)
-              .lineTo(screenCoordinate.x, yTicksMapped.max + axisMargin)
-              .path
-              .strokeColor(Color.gray)
-              .strokeWidth(0.5)
-          )
-      )
-      .on(
-        yTicksSequence
-          .foldLeft(empty[Layout & Path & Style & Shape])((plot, tick) =>
-            val (screenCoordinate, _) = tick
-
-            plot
-              .on(
-                OpenPath.empty
-                  .moveTo(xTicksMapped.min - axisMargin, screenCoordinate.y)
-                  .lineTo(xTicksMapped.max + axisMargin, screenCoordinate.y)
-                  .path
-                  .strokeColor(Color.gray)
-                  .strokeWidth(0.5)
-              )
-          )
-      )
   }
 }
+
 object Plot {
 
   /** Utility constructor to create a `Plot` from a single layer. */

--- a/core/shared/src/main/scala/chartreuse/Plot.scala
+++ b/core/shared/src/main/scala/chartreuse/Plot.scala
@@ -62,7 +62,7 @@ final case class Plot[-Alg <: Algebra](
   def withXTicks(newXTicks: MajorTickLayout): Plot[Alg] = {
     copy(xTicks = newXTicks)
   }
-  
+
   def withYTicks(newYTicks: MajorTickLayout): Plot[Alg] = {
     copy(yTicks = newYTicks)
   }

--- a/core/shared/src/main/scala/chartreuse/TickLayout.scala
+++ b/core/shared/src/main/scala/chartreuse/TickLayout.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package chartreuse
 
 enum MajorTickLayout {

--- a/core/shared/src/main/scala/chartreuse/TickLayout.scala
+++ b/core/shared/src/main/scala/chartreuse/TickLayout.scala
@@ -1,0 +1,12 @@
+package chartreuse
+
+enum MajorTickLayout {
+  case Manual(ticks: Seq[Double])
+  case Algorithmic(tickCount: Int)
+  case NoTicks
+}
+
+enum MinorTickLayout {
+  case Algorithmic(tickCount: Int)
+  case NoTicks
+}


### PR DESCRIPTION
Add support for manual ticks layout.

**Example:**

![image](https://github.com/creativescala/chartreuse/assets/72448226/661c8cd3-c560-4e2b-930a-e2064b3a3194)
