### PR TITLE
Basic support for themeing plots

### DIFF
--- a/core/shared/src/main/scala/chartreuse/Axes.scala
+++ b/core/shared/src/main/scala/chartreuse/Axes.scala
@@ -156,7 +156,9 @@ final case class Axes[-Alg <: Algebra](
     val createXTickLabel
         : (ScreenCoordinate, DataCoordinate) => Picture[Alg & PlotAlg, Unit] =
       (screenCoordinate, dataCoordinate) =>
+        // TODO: take fill from style
         text(numberFormat.format(dataCoordinate.x))
+          .fillColor(Color.black)
           .originAt(Landmark.percent(0, 100))
           .at(screenCoordinate.x, yTicksMin - textMargin)
 
@@ -172,7 +174,9 @@ final case class Axes[-Alg <: Algebra](
     val createYTickLabel
         : (ScreenCoordinate, DataCoordinate) => Picture[Alg & PlotAlg, Unit] =
       (screenCoordinate, dataCoordinate) =>
+        // TODO: take fill from style
         text(numberFormat.format(dataCoordinate.y))
+          .fillColor(Color.black)
           .originAt(Landmark.percent(100, 0))
           .at(xTicksMin - textMargin, screenCoordinate.y)
 
@@ -402,6 +406,7 @@ final case class Axes[-Alg <: Algebra](
           val (layer, theme) = layerAndTheme
           val themed = theme.theme(layer.layout.themeable)
 
+          // TODO: take text fill from style
           content.above(
             circle(circleRadius)
               .fillColor(
@@ -410,7 +415,7 @@ final case class Axes[-Alg <: Algebra](
                   .getOrElse(Color.white)
               )
               .margin(0, legendMargin, 0, 0)
-              .beside(text(layer.label))
+              .beside(text(layer.label).fillColor(Color.black))
               .originAt(Landmark.topLeft)
           )
         })

--- a/core/shared/src/main/scala/chartreuse/Layer.scala
+++ b/core/shared/src/main/scala/chartreuse/Layer.scala
@@ -22,7 +22,6 @@ import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.algebra.Shape
 import doodle.core.BoundingBox
-import doodle.core.Color
 import doodle.core.Point
 
 /** A `Layer` combines data with layout and other properties required to produce
@@ -33,8 +32,7 @@ final case class Layer[A, -Alg <: Algebra](
     toPoint: A => Point,
     scale: Scale,
     layout: Layout[A, Alg],
-    label: String,
-    color: Color
+    label: String
 ) {
   def draw(
       width: Int,
@@ -66,22 +64,18 @@ final case class Layer[A, -Alg <: Algebra](
   def withToPoint(toPoint: A => Point): Layer[A, Alg] =
     this.copy(toPoint = toPoint)
 
-  def withColor(color: Color): Layer[A, Alg] =
-    this.copy(color = color)
-
   def withLabel(label: String): Layer[A, Alg] =
     this.copy(label = label)
 }
 object Layer {
   def apply[A](
       data: Data[A],
-      label: String = "Layer Label",
-      color: Color = Color.cadetBlue
+      label: String = "Layer Label"
   )(toPoint: A => Point): Layer[A, Shape] =
-    Layer(data, toPoint, Scale.linear, Layout.empty, label, color)
+    Layer(data, toPoint, Scale.linear, Layout.empty, label)
 
   def apply[A, Alg <: Algebra](data: Data[A], layout: Layout[A, Alg])(
       toPoint: A => Point
   ): Layer[A, Alg] =
-    Layer(data, toPoint, Scale.linear, layout, "Layer Label", Color.cadetBlue)
+    Layer(data, toPoint, Scale.linear, layout, "Layer Label")
 }

--- a/core/shared/src/main/scala/chartreuse/Layer.scala
+++ b/core/shared/src/main/scala/chartreuse/Layer.scala
@@ -16,6 +16,7 @@
 
 package chartreuse
 
+import cats.Id
 import chartreuse.theme.LayoutTheme
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
@@ -35,12 +36,15 @@ final case class Layer[A, -Alg <: Algebra](
     label: String,
     color: Color
 ) {
-  def draw(width: Int, height: Int): Picture[Alg, Unit] = {
+  def draw(
+      width: Int,
+      height: Int,
+      theme: LayoutTheme[Id]
+  ): Picture[Alg, Unit] = {
     val bb = data.boundingBox(toPoint)
     val s = scale.build(bb, width, height)
 
-    // TODO: pass in a real theme
-    layout.draw(data, toPoint, s, LayoutTheme.default)
+    layout.draw(data, toPoint, s, theme)
   }
 
   def boundingBox: BoundingBox =

--- a/core/shared/src/main/scala/chartreuse/Layer.scala
+++ b/core/shared/src/main/scala/chartreuse/Layer.scala
@@ -16,6 +16,7 @@
 
 package chartreuse
 
+import chartreuse.theme.LayoutTheme
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.algebra.Shape
@@ -38,7 +39,8 @@ final case class Layer[A, -Alg <: Algebra](
     val bb = data.boundingBox(toPoint)
     val s = scale.build(bb, width, height)
 
-    layout.draw(data, toPoint, s, color)
+    // TODO: pass in a real theme
+    layout.draw(data, toPoint, s, LayoutTheme.default)
   }
 
   def boundingBox: BoundingBox =

--- a/core/shared/src/main/scala/chartreuse/Layout.scala
+++ b/core/shared/src/main/scala/chartreuse/Layout.scala
@@ -25,8 +25,13 @@ import doodle.core.Point
 
 trait Layout[A, -Alg <: Algebra] {
 
+  def themeable: LayoutTheme[Themeable]
+
   /** Plot the given data, using the scale to convert from data coordinates to
     * screen coordinates.
+    *
+    * The `theme` has not been combined with this `Layouts` `themeable` value.
+    * The `Layout` should do that itself.
     */
   def draw(
       data: Data[A],
@@ -74,6 +79,7 @@ trait Layout[A, -Alg <: Algebra] {
 object Layout {
   def empty[A]: Layout[A, Shape] =
     new Layout[A, Shape] {
+      val themeable = LayoutTheme.default[Themeable]
       def draw(
           data: Data[A],
           toPoint: A => Point,

--- a/core/shared/src/main/scala/chartreuse/Layout.scala
+++ b/core/shared/src/main/scala/chartreuse/Layout.scala
@@ -21,7 +21,6 @@ import chartreuse.theme.LayoutTheme
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.algebra.Shape
-import doodle.core.Color
 import doodle.core.Point
 
 trait Layout[A, -Alg <: Algebra] {

--- a/core/shared/src/main/scala/chartreuse/Layout.scala
+++ b/core/shared/src/main/scala/chartreuse/Layout.scala
@@ -16,6 +16,8 @@
 
 package chartreuse
 
+import cats.Id
+import chartreuse.theme.LayoutTheme
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.algebra.Shape
@@ -31,7 +33,7 @@ trait Layout[A, -Alg <: Algebra] {
       data: Data[A],
       toPoint: A => Point,
       scale: Point => Point,
-      color: Color
+      theme: LayoutTheme[Id]
   ): Picture[Alg, Unit]
 
   /** Convenience to convert to a `Layer`, by associating this `Layout` with
@@ -77,7 +79,7 @@ object Layout {
           data: Data[A],
           toPoint: A => Point,
           scale: Point => Point,
-          color: Color = Color.cadetBlue
+          theme: LayoutTheme[Id]
       ): Picture[Shape, Unit] =
         doodle.syntax.shape.empty[Shape]
     }

--- a/core/shared/src/main/scala/chartreuse/Plot.scala
+++ b/core/shared/src/main/scala/chartreuse/Plot.scala
@@ -82,7 +82,17 @@ final case class Plot[-Alg <: Algebra](
       theme: PlotTheme[Id] = PlotTheme.default
   ): Picture[Alg & PlotAlg, Unit] = {
     val axes =
-      Axes(xTicks, yTicks, minorTicks, grid, legend, layers, width, height)
+      Axes(
+        xTicks,
+        yTicks,
+        minorTicks,
+        grid,
+        legend,
+        layers,
+        width,
+        height,
+        theme
+      )
     val plotAttributes = axes.build
 
     val allLayers: Picture[Alg & PlotAlg, Unit] =
@@ -92,9 +102,12 @@ final case class Plot[-Alg <: Algebra](
         .foldLeft(empty)(_ on _)
 
     val plotTitle = text(this.plotTitle)
+      .fillColor(Color.black)
       .scale(2, 2)
     val xTitle = text(this.xTitle)
+      .fillColor(Color.black)
     val yTitle = text(this.yTitle)
+      .fillColor(Color.black)
       .rotate(Angle(1.5708))
 
     yTitle

--- a/core/shared/src/main/scala/chartreuse/Plot.scala
+++ b/core/shared/src/main/scala/chartreuse/Plot.scala
@@ -16,6 +16,8 @@
 
 package chartreuse
 
+import cats.Id
+import chartreuse.theme.PlotTheme
 import doodle.algebra.*
 import doodle.core.*
 import doodle.syntax.all.*
@@ -74,14 +76,19 @@ final case class Plot[-Alg <: Algebra](
     copy(yTicks = newYTicks)
   }
 
-  def draw(width: Int, height: Int): Picture[Alg & PlotAlg, Unit] = {
+  def draw(
+      width: Int,
+      height: Int,
+      theme: PlotTheme[Id] = PlotTheme.default
+  ): Picture[Alg & PlotAlg, Unit] = {
     val axes =
       Axes(xTicks, yTicks, minorTicks, grid, legend, layers, width, height)
     val plotAttributes = axes.build
 
     val allLayers: Picture[Alg & PlotAlg, Unit] =
       layers
-        .map(_.draw(width, height))
+        .zip(theme.layerThemesIterator)
+        .map((layer, theme) => layer.draw(width, height, theme))
         .foldLeft(empty)(_ on _)
 
     val plotTitle = text(this.plotTitle)

--- a/core/shared/src/main/scala/chartreuse/Plot.scala
+++ b/core/shared/src/main/scala/chartreuse/Plot.scala
@@ -101,6 +101,9 @@ final case class Plot[-Alg <: Algebra](
         .map((layer, theme) => layer.draw(width, height, theme))
         .foldLeft(empty)(_ on _)
 
+    // TODO: take fill from style
+    // This is a bit of a hack to fill in the text (by default, text on SVG is not filled)
+    // It should be taken from the theme
     val plotTitle = text(this.plotTitle)
       .fillColor(Color.black)
       .scale(2, 2)

--- a/core/shared/src/main/scala/chartreuse/Themeable.scala
+++ b/core/shared/src/main/scala/chartreuse/Themeable.scala
@@ -34,6 +34,20 @@ enum Themeable[A] {
   /** A value that overrides the theme's value */
   case Override(value: A)
 
+  /** True if this is a Default value */
+  def isDefault: Boolean =
+    this match {
+      case Default(_)  => true
+      case Override(_) => false
+    }
+
+  /** True if this is an Override value */
+  def isOverride: Boolean =
+    this match {
+      case Default(_)  => false
+      case Override(_) => true
+    }
+
   /** Convert the value within this [[chartreuse.Themeable]] while keeping the
     * status of default or override the same.
     */

--- a/core/shared/src/main/scala/chartreuse/Themeable.scala
+++ b/core/shared/src/main/scala/chartreuse/Themeable.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chartreuse
+
+import cats.Applicative
+
+/** A [[chartreuse.Themeable]] value is one that can be set from a theme. There
+  * are two cases:
+  *
+  *   - A [[chartreuse.Themeable.Default]] which can be overriden by the theme's
+  *     value; and
+  *   - A [[chartreuse.Themeable.Override]] which will override the theme's
+  *     value.
+  */
+enum Themeable[A] {
+
+  /** A default value that can be overriden by a theme */
+  case Default(value: A)
+
+  /** A value that overrides the theme's value */
+  case Override(value: A)
+
+  /** Convert the value within this [[chartreuse.Themeable]] while keeping the
+    * status of default or override the same.
+    */
+  def map[B](f: A => B): Themeable[B] =
+    this match {
+      case Default(value)  => Default(f(value))
+      case Override(value) => Override(f(value))
+    }
+
+  /** Convert this themeable value to a default */
+  def toDefault: Themeable[A] =
+    this match {
+      case Default(_)      => this
+      case Override(value) => Default(value)
+    }
+
+  /** Convert this themeable value to an override */
+  def toOverride: Themeable[A] =
+    this match {
+      case Default(value) => Override(value)
+      case Override(_)    => this
+    }
+
+  /** Combined this themeable value with the associated value from a theme. */
+  def theme(themeValue: A): A =
+    this match {
+      case Default(_)      => themeValue
+      case Override(value) => value
+    }
+
+  /** Get the value within this themeable container. */
+  def extract: A =
+    this match {
+      case Default(value)  => value
+      case Override(value) => value
+    }
+}
+object Themeable {
+  given Applicative[Themeable] with {
+    def pure[A](value: A): Themeable[A] = Default(value)
+    def ap[A, B](ff: Themeable[A => B])(fa: Themeable[A]): Themeable[B] =
+      fa.map(a => ff.extract(a))
+  }
+}

--- a/core/shared/src/main/scala/chartreuse/layout/Curve.scala
+++ b/core/shared/src/main/scala/chartreuse/layout/Curve.scala
@@ -61,10 +61,14 @@ final case class Curve[
       )
       .path
 
-    theme(curve)
+    theme.theme(themeable)(curve)
   }
 }
 object Curve {
   def default[A]: Curve[A, doodle.algebra.Style & doodle.algebra.Path] =
-    Curve(LayoutTheme.default[Themeable], 0.5)
+    Curve(
+      // Disable fill to avoid filling the open path
+      LayoutTheme.default[Themeable].withFillColor(Themeable.Override(None)),
+      0.5
+    )
 }

--- a/core/shared/src/main/scala/chartreuse/layout/Line.scala
+++ b/core/shared/src/main/scala/chartreuse/layout/Line.scala
@@ -62,7 +62,7 @@ final case class Line[
           path.path
       }
 
-    theme(line)
+    theme.theme(themeable)(line)
   }
 }
 object Line {
@@ -70,5 +70,8 @@ object Line {
     A,
     doodle.algebra.Shape & doodle.algebra.Style & doodle.algebra.Path
   ] =
-    Line(LayoutTheme.default[Themeable])
+    Line(
+      // Disable fill to avoid filling the open path
+      LayoutTheme.default[Themeable].withFillColor(Themeable.Override(None))
+    )
 }

--- a/core/shared/src/main/scala/chartreuse/layout/Line.scala
+++ b/core/shared/src/main/scala/chartreuse/layout/Line.scala
@@ -16,9 +16,10 @@
 
 package chartreuse.layout
 
+import cats.Id
 import chartreuse.*
+import chartreuse.theme.LayoutTheme
 import doodle.algebra.Picture
-import doodle.core.Color
 import doodle.core.OpenPath
 import doodle.core.Point
 import doodle.syntax.all.*
@@ -30,17 +31,24 @@ final case class Line[
     A,
     Alg <: doodle.algebra.Shape & doodle.algebra.Style & doodle.algebra.Path
 ](
-    strokeColor: Color,
-    strokeWidth: Double
+    themeable: LayoutTheme[Themeable]
 ) extends Layout[A, Alg] {
+<<<<<<< HEAD
+=======
+  def forThemeable(
+      f: LayoutTheme[Themeable] => LayoutTheme[Themeable]
+  ): Line[A, Alg] =
+    this.copy(themeable = f(themeable))
+>>>>>>> 70d793c (Basic sketch of theme implementation)
 
-  def withStrokeWidth(strokeWidth: Double): Line[A, Alg] =
-    this.copy(strokeWidth = strokeWidth)
+  def withThemeable(themeable: LayoutTheme[Themeable]): Line[A, Alg] =
+    this.copy(themeable = themeable)
 
   def draw(
       data: Data[A],
       toPoint: A => Point,
       scale: Point => Point,
+<<<<<<< HEAD
       color: Color
   ): Picture[Alg, Unit] = {
     data
@@ -56,6 +64,26 @@ final case class Line[
       case Some(path) =>
         path.path.strokeColor(color).strokeWidth(strokeWidth)
     }
+=======
+      theme: LayoutTheme[Id]
+  ): Picture[Alg, Unit] = {
+    val line =
+      data
+        .foldLeft(None: Option[OpenPath]) { (path, a) =>
+          path match {
+            case None =>
+              Some(OpenPath.empty.moveTo(scale(toPoint(a))))
+            case Some(p) =>
+              Some(p.lineTo(scale(toPoint(a))))
+          }
+        } match {
+        case None => empty
+        case Some(path) =>
+          path.path
+      }
+
+    theme(line)
+>>>>>>> 70d793c (Basic sketch of theme implementation)
   }
 }
 object Line {
@@ -63,5 +91,5 @@ object Line {
     A,
     doodle.algebra.Shape & doodle.algebra.Style & doodle.algebra.Path
   ] =
-    Line(Color.black, 1.0)
+    Line(LayoutTheme.default[Themeable])
 }

--- a/core/shared/src/main/scala/chartreuse/layout/Line.scala
+++ b/core/shared/src/main/scala/chartreuse/layout/Line.scala
@@ -33,13 +33,10 @@ final case class Line[
 ](
     themeable: LayoutTheme[Themeable]
 ) extends Layout[A, Alg] {
-<<<<<<< HEAD
-=======
   def forThemeable(
       f: LayoutTheme[Themeable] => LayoutTheme[Themeable]
   ): Line[A, Alg] =
     this.copy(themeable = f(themeable))
->>>>>>> 70d793c (Basic sketch of theme implementation)
 
   def withThemeable(themeable: LayoutTheme[Themeable]): Line[A, Alg] =
     this.copy(themeable = themeable)
@@ -48,23 +45,6 @@ final case class Line[
       data: Data[A],
       toPoint: A => Point,
       scale: Point => Point,
-<<<<<<< HEAD
-      color: Color
-  ): Picture[Alg, Unit] = {
-    data
-      .foldLeft(None: Option[OpenPath]) { (path, a) =>
-        path match {
-          case None =>
-            Some(OpenPath.empty.moveTo(scale(toPoint(a))))
-          case Some(p) =>
-            Some(p.lineTo(scale(toPoint(a))))
-        }
-      } match {
-      case None => empty
-      case Some(path) =>
-        path.path.strokeColor(color).strokeWidth(strokeWidth)
-    }
-=======
       theme: LayoutTheme[Id]
   ): Picture[Alg, Unit] = {
     val line =
@@ -83,7 +63,6 @@ final case class Line[
       }
 
     theme(line)
->>>>>>> 70d793c (Basic sketch of theme implementation)
   }
 }
 object Line {

--- a/core/shared/src/main/scala/chartreuse/layout/Scatter.scala
+++ b/core/shared/src/main/scala/chartreuse/layout/Scatter.scala
@@ -16,7 +16,9 @@
 
 package chartreuse.layout
 
+import cats.Id
 import chartreuse.*
+import chartreuse.theme.LayoutTheme
 import doodle.algebra.Picture
 import doodle.core.Color
 import doodle.core.Point
@@ -25,7 +27,7 @@ import doodle.syntax.all.*
 
 final case class Scatter[
     A,
-    Alg <: doodle.algebra.Layout & doodle.algebra.Shape
+    Alg <: doodle.algebra.Layout & doodle.algebra.Shape & doodle.algebra.Style
 ](
     glyph: Glyph[Double, Alg],
     toSize: A => Double
@@ -34,11 +36,12 @@ final case class Scatter[
       data: Data[A],
       toPoint: A => Point,
       scale: Point => Point,
-      color: Color
+      theme: LayoutTheme[Id]
   ): Picture[Alg, Unit] = {
-    data.foldLeft(empty[Alg]) { (plot, a) =>
+    val plot = data.foldLeft(empty[Alg]) { (plot, a) =>
       glyph.draw(toSize(a)).at(scale(toPoint(a))).on(plot)
     }
+    theme(plot)
   }
 }
 object Scatter {

--- a/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
+++ b/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
@@ -36,7 +36,7 @@ import doodle.syntax.all.*
   *   - [[cats.Id]] for values that have combined [[chartreuse.Themeable]] with
   *     a theme.
   */
-// This doesn't cover all the possibilities for themeing layouts. For example,
+// This doesn't cover all the possibilities for theming layouts. For example,
 // there is no stroke dash specified. This is a first pass. Extend it if needed.
 final case class LayoutTheme[F[_]: Applicative](
     strokeColor: F[Option[Color]],

--- a/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
+++ b/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chartreuse.theme
+
+import cats.Applicative
+import cats.Comonad
+import cats.Id
+import cats.syntax.all.*
+import chartreuse.Themeable
+import doodle.algebra.Algebra
+import doodle.algebra.Picture
+import doodle.algebra.Style
+import doodle.core.Color
+import doodle.syntax.all.*
+
+/** Generic container for the theme of a [[chartreuse.Layout]]. The type
+  * [[this.F!]] determines the wrapper type for values in this theme. It should
+  * be
+  *
+  *   - [[chartreuse.Themeable]] for values that can have a theme applied to
+  *     them
+  *   - [[cats.Id]] for values that have combined [[chartreuse.Themeable]] with
+  *     a theme.
+  */
+// This doesn't cover all the possibilities for themeing layouts. For example,
+// there is no stroke dash specified. This is a first pass. Extend it if needed.
+final case class LayoutTheme[F[_]: Applicative](
+    strokeColor: F[Option[Color]],
+    strokeWidth: F[Double],
+    fillColor: F[Option[Color]]
+) {
+  def withFillColor(fillColor: Color): LayoutTheme[F] =
+    this.copy(fillColor = fillColor.some.pure[F])
+
+  def withNoFill: LayoutTheme[F] =
+    this.copy(fillColor = none.pure[F])
+
+  def withStrokeColor(strokeColor: Color): LayoutTheme[F] =
+    this.copy(strokeColor = strokeColor.some.pure[F])
+
+  def withNoStroke: LayoutTheme[F] =
+    this.copy(strokeColor = none.pure[F])
+
+  def withStrokeWidth(strokeWidth: Double): LayoutTheme[F] =
+    this.copy(strokeWidth = strokeWidth.pure[F])
+
+  def theme(themeable: LayoutTheme[Themeable])(using
+      Comonad[F]
+  ): LayoutTheme[Id] =
+    LayoutTheme(
+      themeable.strokeColor.theme(strokeColor.extract).pure[Id],
+      themeable.strokeWidth.theme(strokeWidth.extract).pure[Id],
+      themeable.fillColor.theme(fillColor.extract).pure[Id]
+    )
+
+  /** Apply the style in this theme to a [[doodle.algebra.Picture]] */
+  def apply[Alg <: Algebra, A](
+      picture: Picture[Alg, A]
+  )(using Comonad[F]): Picture[Alg & Style, A] = {
+    val p1 =
+      strokeColor.extract.fold(picture.noStroke)(c => picture.strokeColor(c))
+    val p2 =
+      fillColor.extract.fold(p1.noFill)(c => p1.fillColor(c))
+
+    p2.strokeWidth(strokeWidth.extract)
+  }
+}
+object LayoutTheme {
+
+  /** A default theme, with a black stroke and no fill. */
+  def default[F[_]: Applicative]: LayoutTheme[F] =
+    LayoutTheme(Color.black.some.pure[F], 1.0.pure[F], none.pure[F])
+}

--- a/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
+++ b/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
@@ -67,7 +67,7 @@ final case class LayoutTheme[F[_]: Applicative](
       themeable.fillColor.theme(fillColor.extract).pure[Id]
     )
 
-  /** Apply the style in this theme to a [[doodle.algebra.Picture]] */
+  /** Apply the style of this theme to a [[doodle.algebra.Picture]] */
   def apply[Alg <: Algebra, A](
       picture: Picture[Alg, A]
   )(using Comonad[F]): Picture[Alg & Style, A] = {

--- a/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
+++ b/core/shared/src/main/scala/chartreuse/theme/LayoutTheme.scala
@@ -43,21 +43,67 @@ final case class LayoutTheme[F[_]: Applicative](
     strokeWidth: F[Double],
     fillColor: F[Option[Color]]
 ) {
+
+  /** Builder method to set the fillColor of this [[LayoutTheme]]. */
+  def withFillColor(fillColor: F[Option[Color]]): LayoutTheme[F] =
+    this.copy(fillColor = fillColor)
+
+  /** Convenience builder method to set the fillColor of this [[LayoutTheme]].
+    * This will call the `pure` method on `F` to construct an instance of
+    * `F[Option[Color]]`. For a [[chartreuse.Themeable]] value this will be
+    * `Default` value, not an `Override`, which is probably not what you want.
+    * Use the other overloaded `withFillColor` method instead.
+    */
   def withFillColor(fillColor: Color): LayoutTheme[F] =
     this.copy(fillColor = fillColor.some.pure[F])
 
+  /** Convenience builder method to set the fillColor of this [[LayoutTheme]] to
+    * `None`. This will call the `pure` method on `F` to construct an instance
+    * of `F[Option[Color]]`. For a [[chartreuse.Themeable]] value this will be
+    * `Default` value, not an `Override`, which is probably not what you want.
+    * Use the `withFillColor` method instead.
+    */
   def withNoFill: LayoutTheme[F] =
     this.copy(fillColor = none.pure[F])
 
+  /** Builder method to set the strokeColor of this [[LayoutTheme]]. */
   def withStrokeColor(strokeColor: Color): LayoutTheme[F] =
     this.copy(strokeColor = strokeColor.some.pure[F])
 
+  /** Convenience builder method to set the strokeColor of this [[LayoutTheme]].
+    * This will call the `pure` method on `F` to construct an instance of
+    * `F[Option[Color]]`. For a [[chartreuse.Themeable]] value this will be
+    * `Default` value, not an `Override`, which is probably not what you want.
+    * Use the other overloaded `withStrokeColor` method instead.
+    */
+  def withStrokeColor(strokeColor: F[Option[Color]]): LayoutTheme[F] =
+    this.copy(strokeColor = strokeColor)
+
+  /** Convenience builder method to set the strokeColor of this [[LayoutTheme]]
+    * to `None`. This will call the `pure` method on `F` to construct an
+    * instance of `F[Option[Color]]`. For a [[chartreuse.Themeable]] value this
+    * will be `Default` value, not an `Override`, which is probably not what you
+    * want. Use the `withStrokeColor` method instead.
+    */
   def withNoStroke: LayoutTheme[F] =
     this.copy(strokeColor = none.pure[F])
 
+  /** Builder method to set the strokeWidth of this [[LayoutTheme]]. */
+  def withStrokeWidth(strokeWidth: F[Double]): LayoutTheme[F] =
+    this.copy(strokeWidth = strokeWidth)
+
+  /** Convenience builder method to set the strokeWidth of this [[LayoutTheme]].
+    * This will call the `pure` method on `F` to construct an instance of
+    * `F[Double]`. For a [[chartreuse.Themeable]] value this will be `Default`
+    * value, not an `Override`, which is probably not what you want. Use the
+    * other overloaded `withStrokeWidth` method instead.
+    */
   def withStrokeWidth(strokeWidth: Double): LayoutTheme[F] =
     this.copy(strokeWidth = strokeWidth.pure[F])
 
+  /** Combine this `LayoutTheme` with the Themeable values in the theme in the
+    * argument.
+    */
   def theme(themeable: LayoutTheme[Themeable])(using
       Comonad[F]
   ): LayoutTheme[Id] =

--- a/core/shared/src/main/scala/chartreuse/theme/PlotTheme.scala
+++ b/core/shared/src/main/scala/chartreuse/theme/PlotTheme.scala
@@ -98,6 +98,65 @@ object PlotTheme {
       )
     )
 
+  /** FiveThirtyEight theme, modeled after https://fivethirtyeight.com/
+    *
+    * Taken from
+    * https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
+    * Copyright (c) 2012- Matplotlib Development Team; All Rights Reserved
+    */
+  val fiveThirtyEight: PlotTheme[Id] =
+    fromColors(
+      NonEmptySeq
+        .of("008fd5", "fc4f30", "e5ae38", "6d904f", "8b8b8b", "810f7c")
+        .map(hexToColor)
+    )
+
+  /** Bayesian Methods for Hackers theme, modeled after
+    * https://dataorigami.net/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/
+    *
+    * Taken from
+    * https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/mpl-data/stylelib/bmh.mplstyle
+    * Copyright (c) 2012- Matplotlib Development Team; All Rights Reserved
+    */
+  val bmh: PlotTheme[Id] =
+    fromColors(
+      NonEmptySeq
+        .of(
+          "348ABD",
+          "A60628",
+          "7A68A6",
+          "467821",
+          "D55E00",
+          "CC79A7",
+          "56B4E9",
+          "009E73",
+          "F0E442",
+          "0072B2"
+        )
+        .map(hexToColor)
+    )
+
+  /** ggplot theme
+    *
+    * Taken from
+    * https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/mpl-data/stylelib/ggplot.mplstyle
+    * Copyright (c) 2012- Matplotlib Development Team; All Rights Reserved
+    */
+  val ggplot: PlotTheme[Id] =
+    fromColors(
+      NonEmptySeq
+        .of(
+          "E24A33",
+          "348ABD",
+          "988ED5",
+          "777777",
+          "FBC15E",
+          "8EBA42",
+          "FFB5B8"
+        )
+        .map(hexToColor)
+    )
+
   /** Base 16 themes taken from
     * https://github.com/chriskempson/base16-default-schemes
     */

--- a/core/shared/src/main/scala/chartreuse/theme/PlotTheme.scala
+++ b/core/shared/src/main/scala/chartreuse/theme/PlotTheme.scala
@@ -64,21 +64,186 @@ object PlotTheme {
   def apply[F[_]: Applicative](layerTheme: LayoutTheme[F]): PlotTheme[F] =
     PlotTheme(NonEmptySeq.of(layerTheme))
 
-  /** A simple default theme, with colours chosen to look something like the
-    * ggplot default theme.
+  /** Convert a six-character hex string, which does not start with #, to a
+    * `Color`.
+    */
+  def hexToColor(hex: String): Color = {
+    val r = Integer.parseInt(hex.substring(0, 2), 16)
+    val g = Integer.parseInt(hex.substring(2, 4), 16)
+    val b = Integer.parseInt(hex.substring(4, 6), 16)
+
+    Color.rgb(r, g, b)
+  }
+
+  /** Convert a sequence of colors to a [[PlotTheme]]. */
+  def fromColors(colors: NonEmptySeq[Color]): PlotTheme[Id] =
+    PlotTheme[Id](
+      colors.map(c =>
+        LayoutTheme.default[Id].withFillColor(c).withStrokeColor(c)
+      )
+    )
+
+  /** A simple default theme, with colours chosen to look reasonably pleasing.
     */
   val default =
-    PlotTheme[Id](
-      NonEmptySeq
-        .of(
-          Color.orange,
-          Color.purple,
-          Color.blue,
-          Color.turquoise,
-          Color.red,
-          Color.pink,
-          Color.green
-        )
-        .map(c => LayoutTheme.default[Id].withFillColor(c).withStrokeColor(c))
+    fromColors(
+      NonEmptySeq.of(
+        Color.orange,
+        Color.purple,
+        Color.blue,
+        Color.turquoise,
+        Color.red,
+        Color.pink,
+        Color.green
+      )
     )
+
+  /** Base 16 themes taken from
+    * https://github.com/chriskempson/base16-default-schemes
+    */
+  object base16 {
+    val defaultLight: PlotTheme[Id] =
+      fromColors(
+        NonEmptySeq
+          .of(
+            "f8f8f8",
+            "e8e8e8",
+            "d8d8d8",
+            "b8b8b8",
+            "585858",
+            "383838",
+            "282828",
+            "181818",
+            "ab4642",
+            "dc9656",
+            "f7ca88",
+            "a1b56c",
+            "86c1b9",
+            "7cafc2",
+            "ba8baf",
+            "a16946"
+          )
+          .map(hexToColor)
+      )
+
+    val defaultDark: PlotTheme[Id] =
+      fromColors(
+        NonEmptySeq
+          .of(
+            "181818",
+            "282828",
+            "383838",
+            "585858",
+            "b8b8b8",
+            "d8d8d8",
+            "e8e8e8",
+            "f8f8f8",
+            "ab4642",
+            "dc9656",
+            "f7ca88",
+            "a1b56c",
+            "86c1b9",
+            "7cafc2",
+            "ba8baf",
+            "a16946"
+          )
+          .map(hexToColor)
+      )
+
+    val cupcake: PlotTheme[Id] =
+      fromColors(
+        NonEmptySeq
+          .of(
+            "fbf1f2",
+            "f2f1f4",
+            "d8d5dd",
+            "bfb9c6",
+            "a59daf",
+            "8b8198",
+            "72677E",
+            "585062",
+            "D57E85",
+            "EBB790",
+            "DCB16C",
+            "A3B367",
+            "69A9A7",
+            "7297B9",
+            "BB99B4",
+            "BAA58C"
+          )
+          .map(hexToColor)
+      )
+
+    val eighties: PlotTheme[Id] =
+      fromColors(
+        NonEmptySeq
+          .of(
+            "2d2d2d",
+            "393939",
+            "515151",
+            "747369",
+            "a09f93",
+            "d3d0c8",
+            "e8e6df",
+            "f2f0ec",
+            "f2777a",
+            "f99157",
+            "ffcc66",
+            "99cc99",
+            "66cccc",
+            "6699cc",
+            "cc99cc",
+            "d27b53"
+          )
+          .map(hexToColor)
+      )
+
+    val mocha: PlotTheme[Id] =
+      fromColors(
+        NonEmptySeq
+          .of(
+            "3B3228",
+            "534636",
+            "645240",
+            "7e705a",
+            "b8afad",
+            "d0c8c6",
+            "e9e1dd",
+            "f5eeeb",
+            "cb6077",
+            "d28b71",
+            "f4bc87",
+            "beb55b",
+            "7bbda4",
+            "8ab3b5",
+            "a89bb9",
+            "bb9584"
+          )
+          .map(hexToColor)
+      )
+
+    val ocean: PlotTheme[Id] =
+      fromColors(
+        NonEmptySeq
+          .of(
+            "2b303b",
+            "343d46",
+            "4f5b66",
+            "65737e",
+            "a7adba",
+            "c0c5ce",
+            "dfe1e8",
+            "eff1f5",
+            "bf616a",
+            "d08770",
+            "ebcb8b",
+            "a3be8c",
+            "96b5b4",
+            "8fa1b3",
+            "b48ead",
+            "ab7967"
+          )
+          .map(hexToColor)
+      )
+  }
 }

--- a/core/shared/src/main/scala/chartreuse/theme/PlotTheme.scala
+++ b/core/shared/src/main/scala/chartreuse/theme/PlotTheme.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chartreuse.theme
+
+import cats.Applicative
+import cats.Comonad
+import cats.Id
+import cats.data.NonEmptySeq
+import doodle.core.Color
+
+/** Generic container for the theme of a [[chartreuse.Plot]]. Contains one or
+  * more [[chartreuse.theme.LayoutTheme]]. Each layer in the plot will take a
+  * successive theme from this sequence. In case there are more layers than
+  * themes, the sequence will start again at the beginning.
+  */
+// There are more elements that could be themed, such as font family, size, and
+// so on. Expand this as needed.
+final case class PlotTheme[F[_]: Applicative](
+    layerThemes: NonEmptySeq[LayoutTheme[F]]
+) {
+  def addLayerTheme(theme: LayoutTheme[F]): PlotTheme[F] =
+    this.copy(layerThemes = layerThemes :+ theme)
+
+  /** Produces an [[scala.collection.Iterator]] through the layer themes. This
+    * iterator never terminates; it *always* produces a value. The values are
+    * the layerThemes in-order, wrapping back to the start if needed. In other
+    * words it acts as a circular array.
+    */
+  def layerThemesIterator(using comonad: Comonad[F]): Iterator[LayoutTheme[F]] =
+    new Iterator[LayoutTheme[F]] {
+      private var elements = layerThemes.toSeq.toArray
+      private var idx = 0
+
+      def hasNext(): Boolean = true
+
+      def next(): LayoutTheme[F] = {
+        if idx >= elements.size then idx = 0
+        val result = elements(idx)
+        idx = idx + 1
+
+        result
+      }
+    }
+}
+object PlotTheme {
+
+  /** Convenience constructor to create a [[PlotTheme]] from a single
+    * [[LayoutTheme]].
+    */
+  def apply[F[_]: Applicative](layerTheme: LayoutTheme[F]): PlotTheme[F] =
+    PlotTheme(NonEmptySeq.of(layerTheme))
+
+  /** A simple default theme, with colours chosen to look something like the
+    * ggplot default theme.
+    */
+  val default =
+    PlotTheme[Id](
+      NonEmptySeq
+        .of(
+          Color.orange,
+          Color.purple,
+          Color.blue,
+          Color.turquoise,
+          Color.red,
+          Color.pink,
+          Color.green
+        )
+        .map(c => LayoutTheme.default[Id].withFillColor(c).withStrokeColor(c))
+    )
+}

--- a/core/shared/src/test/scala/chartreuse/ThemeableSuite.scala
+++ b/core/shared/src/test/scala/chartreuse/ThemeableSuite.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chartreuse
+
+import munit.FunSuite
+
+class ThemeableSuite extends FunSuite {
+  test("default values are overriden by theme value") {
+    assertEquals(Themeable.Default(3).theme(4), 4)
+  }
+
+  test("override values override theme value") {
+    assertEquals(Themeable.Override(3).theme(4), 3)
+  }
+}

--- a/core/shared/src/test/scala/chartreuse/theme/LayoutThemeSuite.scala
+++ b/core/shared/src/test/scala/chartreuse/theme/LayoutThemeSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chartreuse.theme
+
+import chartreuse.Themeable
+import doodle.core.Color
+import munit.FunSuite
+
+class LayoutThemeSuite extends FunSuite {
+  val exampleTheme = PlotTheme.base16.defaultLight.layerThemes.head
+  val default = LayoutTheme.default[Themeable]
+
+  test("Default Themeable LayoutTheme has all Default values") {
+    assert(default.strokeColor.isDefault)
+    assert(default.strokeWidth.isDefault)
+    assert(default.fillColor.isDefault)
+  }
+
+  test("Theming chooses theme values over Default values") {
+    val themed = exampleTheme.theme(default)
+    assertEquals(themed.strokeColor, exampleTheme.strokeColor)
+    assertEquals(themed.strokeWidth, exampleTheme.strokeWidth)
+    assertEquals(themed.fillColor, exampleTheme.fillColor)
+  }
+
+  test("Theming chooses Override values over theme values") {
+    val overriden =
+      default
+        .withStrokeColor(Themeable.Override(Some(Color.chartreuse)))
+        .withFillColor(Themeable.Override(Some(Color.aliceBlue)))
+        .withStrokeWidth(Themeable.Override(5.0))
+
+    val themed = exampleTheme.theme(overriden)
+
+    assertEquals(themed.strokeColor, Some(Color.chartreuse))
+    assertEquals(themed.strokeWidth, 5.0)
+    assertEquals(themed.fillColor, Some(Color.aliceBlue))
+  }
+}

--- a/docs/src/pages/directory.conf
+++ b/docs/src/pages/directory.conf
@@ -3,6 +3,7 @@ laika.navigationOrder = [
   quick-start.md
   concepts.md
   creating-visualizations.md
+  themes.md
   examples.md
   development.md
 ]

--- a/docs/src/pages/examples.md
+++ b/docs/src/pages/examples.md
@@ -3,8 +3,6 @@
 
 ## Scatter Plot
 
-@:doodle("scatter-plot", "ScatterPlotExample.draw")
-
 @:doodle("plot", "PlotExample.draw")
 
 

--- a/docs/src/pages/themes.md
+++ b/docs/src/pages/themes.md
@@ -1,6 +1,6 @@
 # Themes
 
-Themeing controls colors, fills, and other similar aspects of the visual appearance of plots.
+Theming controls colors, fills, and other similar aspects of the visual appearance of plots.
 There are two concepts that combine in Chartreuse's theme system:
 
 - themes, which specify collections of values to control the visual appearance of plots; and

--- a/docs/src/pages/themes.md
+++ b/docs/src/pages/themes.md
@@ -10,17 +10,63 @@ There are two concepts in Chartreuse's theme system:
 ## Themes
 
 Themes are found within the `chartreuse.theme` package.
-Most users will apply a theme to a whole plot, using @:api(chartreuse.theme.PlotTheme).
+Most users will apply a theme to a whole plot, using a @:api(chartreuse.theme.PlotTheme).
 There are a small number of predefined `PlotThemes` available in Chartreuse:
 
-- @:api(chartreuse.theme.PlotTheme.default), the default theme; and
+- @:api(chartreuse.theme.PlotTheme.default), the default theme;
 - the themes defined within @:api(chartreuse.theme.PlotTheme.base16): `defaultLight`, `defaultDark`, and so on.
+- @:api(chartreuse.theme.PlotTheme.fiveThirtyEight);
+- @:api(chartreuse.theme.PlotTheme.bmh); and
+- @:api(chartreuse.theme.PlotTheme.ggplot).
+
+To apply a theme to a `Plot`, pass it to the `draw` method. For example, instead of calling
+
+```scala
+aPlot.draw(640, 480)
+```
+
+call
+
+```scala
+aPlot.draw(640, 480, PlotTheme.base16.defaultLight)
+```
 
 
 ## Themeable Values
 
-Where settings in Chartreuse can be themed they are represented as @:api(chartreuse.Themeable) values.
+Where a value in Chartreuse can be themed it is represented as a @:api(chartreuse.Themeable) value.
 For example, @:api(chartreuse.layout.Curve) contains a @:api(chartreuse.theme.LayoutTheme) which in turn contains `Themeable` values for `strokeColor`, `fillColor`, and so on.
 
-@:api(chartreuse.Themeable) values allow theme choices to be overriden. A `Themeable` value specifies either a @:api(chartreuse.Themeable.Default), which will be overriden by the theme's value, if there is one, or a  @:api(chartreuse.Themeable.Override), which will override the theme's value.
+A `Themeable` value specifies either a @:api(chartreuse.Themeable.Default), which will be overriden by the theme's value, if there is one, or an @:api(chartreuse.Themeable.Override), which will override the theme's value. So, for example, if a `Themeable` `strokeColor` is `Themeable.Default(Color.red)`, this value will be overriden by the theme's `strokeColor`. However, if the value is `Themeable.Override(Color.red)` it will override the theme.
 
+When changing `Themeable` values it's usually the case you want to override the theme. Here's an example creating a @:api(chartreuse.layout.Line) layout and overriding the theme with custom stroke color and width.
+
+```scala
+Line
+  .default[Point]
+  .forThemeable(theme =>
+    theme
+      .withStrokeColor(Themeable.Override(Some(Color.darkBlue)))
+      .withStrokeWidth(Themeable.Override(3.0))
+  )
+```
+
+
+## Theme Gallery
+
+Here are examples of some of the available themes.
+
+### Default Theme
+@:doodle(theme-default, PlotExample.drawDefault)
+
+### BMH Theme
+@:doodle(theme-bmh, PlotExample.drawBmh)
+
+### FiveThirtyEight Theme
+@:doodle(theme-fivethirtyeight, PlotExample.drawFiveThirtyEight)
+
+### Base16 Default Light Theme
+@:doodle(theme-base16-default-light, PlotExample.drawBase16DefaultLight)
+
+### Base16 Ocean Theme
+@:doodle(theme-base16-ocean, PlotExample.drawBase16Ocean)

--- a/docs/src/pages/themes.md
+++ b/docs/src/pages/themes.md
@@ -1,0 +1,8 @@
+# Themes
+
+Themeing controls colors, fills, and other similar aspects of the visual appearance of plots.
+There are two concepts that combine in Chartreuse's theme system:
+
+- themes, which specify collections of values to control the visual appearance of plots; and
+- @:api(chartreuse.Themeable) values, which allow the user to override the theme values with settings of their own choice.
+

--- a/docs/src/pages/themes.md
+++ b/docs/src/pages/themes.md
@@ -20,7 +20,7 @@ There are a small number of predefined `PlotThemes` available in Chartreuse:
 ## Themeable Values
 
 Where settings in Chartreuse can be themed they are represented as @:api(chartreuse.Themeable) values.
-For example, @:api(chartreuse.layout.Curve) contains a @:api(chartreuse.theme.LayouTheme) which in turn contains `Themeable` values for `strokeColor`, `fillColor`, and so on.
+For example, @:api(chartreuse.layout.Curve) contains a @:api(chartreuse.theme.LayoutTheme) which in turn contains `Themeable` values for `strokeColor`, `fillColor`, and so on.
 
 @:api(chartreuse.Themeable) values allow theme choices to be overriden. A `Themeable` value specifies either a @:api(chartreuse.Themeable.Default), which will be overriden by the theme's value, if there is one, or a  @:api(chartreuse.Themeable.Override), which will override the theme's value.
 

--- a/docs/src/pages/themes.md
+++ b/docs/src/pages/themes.md
@@ -1,8 +1,26 @@
-# Themes
+# Theming Plots
 
-Theming controls colors, fills, and other similar aspects of the visual appearance of plots.
-There are two concepts that combine in Chartreuse's theme system:
+Theming controls colors, fills, and other aspects of the visual appearance of plots.
+There are two concepts in Chartreuse's theme system:
 
-- themes, which specify collections of values to control the visual appearance of plots; and
+- themes, which specify collections of values that control the visual appearance of plots; and
 - @:api(chartreuse.Themeable) values, which allow the user to override the theme values with settings of their own choice.
+
+
+## Themes
+
+Themes are found within the `chartreuse.theme` package.
+Most users will apply a theme to a whole plot, using @:api(chartreuse.theme.PlotTheme).
+There are a small number of predefined `PlotThemes` available in Chartreuse:
+
+- @:api(chartreuse.theme.PlotTheme.default), the default theme; and
+- the themes defined within @:api(chartreuse.theme.PlotTheme.base16): `defaultLight`, `defaultDark`, and so on.
+
+
+## Themeable Values
+
+Where settings in Chartreuse can be themed they are represented as @:api(chartreuse.Themeable) values.
+For example, @:api(chartreuse.layout.Curve) contains a @:api(chartreuse.theme.LayouTheme) which in turn contains `Themeable` values for `strokeColor`, `fillColor`, and so on.
+
+@:api(chartreuse.Themeable) values allow theme choices to be overriden. A `Themeable` value specifies either a @:api(chartreuse.Themeable.Default), which will be overriden by the theme's value, if there is one, or a  @:api(chartreuse.Themeable.Override), which will override the theme's value.
 

--- a/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
+++ b/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
@@ -288,13 +288,17 @@ object BahamasPopulation {
     Line
       .default[Point]
       .forThemeable(theme =>
-        theme.withStrokeColor(Color.darkBlue).withStrokeWidth(3.0)
+        theme
+          .withStrokeColor(Themeable.Override(Some(Color.darkBlue)))
+          .withStrokeWidth(Themeable.Override(3.0))
       )
   val curve =
     Curve
       .default[Point]
       .forThemeable(theme =>
-        theme.withStrokeColor(Color.lawngreen).withStrokeWidth(7.0)
+        theme
+          .withStrokeColor(Themeable.Override(Some(Color.lawngreen)))
+          .withStrokeWidth(Themeable.Override(7.0))
       )
 
   val plot =

--- a/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
+++ b/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
@@ -285,9 +285,17 @@ object BahamasPopulation {
     )
 
   val line =
-    Line.default[Point].withStrokeWidth(3.0)
+    Line
+      .default[Point]
+      .forThemeable(theme =>
+        theme.withStrokeColor(Color.darkBlue).withStrokeWidth(3.0)
+      )
   val curve =
-    Curve.default[Point].withStrokeWidth(7.0)
+    Curve
+      .default[Point]
+      .forThemeable(theme =>
+        theme.withStrokeColor(Color.lawngreen).withStrokeWidth(7.0)
+      )
 
   val plot =
     Plot(

--- a/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
+++ b/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
@@ -17,8 +17,8 @@
 package chartreuse.examples
 
 import cats.effect.unsafe.implicits.global
+import chartreuse.*
 import chartreuse.layout.*
-import chartreuse.{*, given}
 import doodle.core.Color
 import doodle.core.Point
 import doodle.svg.*

--- a/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
+++ b/examples/src/main/scala/chartreuse/examples/BahamasPopulation.scala
@@ -304,8 +304,8 @@ object BahamasPopulation {
   val plot =
     Plot(
       List(
-        line.toLayer(population).withColor(Color.darkBlue).withLabel("Line"),
-        curve.toLayer(population).withColor(Color.lawngreen).withLabel("Curve")
+        line.toLayer(population).withLabel("Line"),
+        curve.toLayer(population).withLabel("Curve")
       )
     )
       .withPlotTitle("Bahamas Population")

--- a/examples/src/main/scala/chartreuse/examples/PlotExample.scala
+++ b/examples/src/main/scala/chartreuse/examples/PlotExample.scala
@@ -17,8 +17,8 @@
 package chartreuse.examples
 
 import cats.effect.unsafe.implicits.global
+import chartreuse.*
 import chartreuse.layout.Scatter
-import chartreuse.{*, given}
 import doodle.core.Point
 import doodle.language.Basic
 import doodle.svg.*

--- a/examples/src/main/scala/chartreuse/examples/PlotExample.scala
+++ b/examples/src/main/scala/chartreuse/examples/PlotExample.scala
@@ -19,6 +19,7 @@ package chartreuse.examples
 import cats.effect.unsafe.implicits.global
 import chartreuse.*
 import chartreuse.layout.Scatter
+import chartreuse.theme.PlotTheme
 import doodle.core.Point
 import doodle.language.Basic
 import doodle.svg.*
@@ -47,4 +48,24 @@ object PlotExample {
   @JSExport
   def draw(id: String): Unit =
     plot.draw(640, 480).drawWithFrame(Frame(id))
+
+  @JSExport
+  def drawDefault(id: String): Unit =
+    plot.draw(320, 240, PlotTheme.default).drawWithFrame(Frame(id))
+
+  @JSExport
+  def drawBmh(id: String): Unit =
+    plot.draw(320, 240, PlotTheme.bmh).drawWithFrame(Frame(id))
+
+  @JSExport
+  def drawFiveThirtyEight(id: String): Unit =
+    plot.draw(320, 240, PlotTheme.fiveThirtyEight).drawWithFrame(Frame(id))
+
+  @JSExport
+  def drawBase16DefaultLight(id: String): Unit =
+    plot.draw(320, 240, PlotTheme.base16.defaultLight).drawWithFrame(Frame(id))
+
+  @JSExport
+  def drawBase16Ocean(id: String): Unit =
+    plot.draw(320, 240, PlotTheme.base16.ocean).drawWithFrame(Frame(id))
 }

--- a/examples/src/main/scala/chartreuse/examples/QuickStart.scala
+++ b/examples/src/main/scala/chartreuse/examples/QuickStart.scala
@@ -17,8 +17,8 @@
 package chartreuse.examples
 
 import cats.effect.unsafe.implicits.global
+import chartreuse.*
 import chartreuse.layout.Scatter
-import chartreuse.{*, given}
 import doodle.core.Point
 import doodle.svg.*
 import doodle.syntax.all.*

--- a/examples/src/main/scala/chartreuse/examples/ScatterPlotExample.scala
+++ b/examples/src/main/scala/chartreuse/examples/ScatterPlotExample.scala
@@ -19,6 +19,7 @@ package chartreuse.examples
 import cats.effect.unsafe.implicits.global
 import chartreuse.*
 import chartreuse.layout.Scatter
+import chartreuse.theme.LayoutTheme
 import doodle.core.Point
 import doodle.svg.*
 import doodle.syntax.all.*
@@ -38,5 +39,5 @@ object ScatterPlotExample {
 
   @JSExport
   def draw(id: String): Unit =
-    layer.draw(640, 480).drawWithFrame(Frame(id))
+    layer.draw(640, 480, LayoutTheme.default).drawWithFrame(Frame(id))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   // Library Versions
-  val catsVersion = "2.9.0"
+  val catsVersion = "2.10.0"
   val catsEffectVersion = "3.5.1"
   val fs2Version = "3.6.1"
 


### PR DESCRIPTION
This WIP adds basic support for theming plots. What we have:

* A way to represent style values that can be overridden by a theme, or override a theme
* A way to represent a theme
* Very basic implementation for `Layout`

Things to do:

- [x] Implement some actual themes
- [x] Pass themes through from `Plot`
- [x] Complete documentation
- [x] Correct typos: themeing -> theming

To consider:

- Should there be a hierarchy of themes, and inheritance between them.
- Clean up `Glyph` implementation, so it doesn't have its own theming code
- Add colour back to our examples. I.e. add a default theme that looks ok.